### PR TITLE
Metadata for raid module

### DIFF
--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1187,8 +1187,6 @@ raid_bdev_base_bdev_read_sb_compete(struct spdk_bdev_io *bdev_io, bool success, 
     }
 
     spdk_bdev_free_io(bdev_io);
-
-    base_info->sb_loaded = true;
 }
 
 static int
@@ -1196,9 +1194,6 @@ raid_bdev_base_bdev_read_sb(struct raid_base_bdev_info *base_info, uint32_t sb_s
 {
     int rc = 0;
     struct spdk_io_channel *ch;
-
-    if (base_info->sb_loaded)
-        return 0;
 
     ch = spdk_bdev_get_io_channel(base_info->desc);
 
@@ -1230,7 +1225,6 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
     rc = raid_bdev_base_bdev_read_sb(base_info, RAID_SB_BLOCKS(base_bdev->blocklen));
     if (rc) {
         SPDK_ERRLOG("Failed while read superblock from base bdev '%s'\n", base_info->name);
-        base_info->sb_loaded = false;
         return rc;
     }
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -795,6 +795,16 @@ static struct {
 	{ }
 };
 
+bool
+raid_bdev_is_raid_level(uint32_t level) {
+    for (int i = 0; g_raid_level_names[i].name != NULL; i++) {
+        if (level == g_raid_level_names[i].value)
+            return true;
+    }
+
+    return false;
+}
+
 /* We have to use the typedef in the function declaration to appease astyle. */
 typedef enum raid_level raid_level_t;
 typedef enum raid_bdev_state raid_bdev_state_t;

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1289,6 +1289,8 @@ raid_bdev_super_init_validation(struct raid_bdev *raid, struct raid_base_bdev_in
     spdk_uuid_copy(&raid->bdev.uuid, &sb->uuid);
     raid->strip_size = sb->strip_size;
     raid->strip_size_kb = sb->strip_size * sb->blocklen;
+    raid->strip_size_shift = spdk_u32log2(sb->strip_size);
+    raid->blocklen_shift = spdk_u32log2(sb->blocklen);
 
     raid->is_new = false;
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1186,8 +1186,7 @@ static int
 raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct raid_base_bdev_info **freshest)
 {
     int rc = 0;
-    uint32_t sb_blocks = spdk_divide_round_up(sizeof(struct raid_superblock),
-                                              spdk_bdev_desc_get_bdev(base_info->desc)->blocklen);
+    struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
 
     base_info->raid_sb = calloc(1, sb_blocks);
     if (!base_info->raid_sb) {
@@ -1195,7 +1194,7 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
         return -ENOMEM;
     }
 
-    rc = raid_bdev_load_base_bdevs_sb(base_info, sb_blocks);
+    rc = raid_bdev_load_base_bdevs_sb(base_info, RAID_SB_BLOCKS(base_bdev->blocklen));
     if (rc) {
         SPDK_ERRLOG("Failed while read superblock from base bdev '%s'\n", base_info->name);
         goto bad;

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1391,7 +1391,7 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
     RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
         rc = raid_bdev_base_bdev_super_load(base_info, &freshest);
         if (rc) {
-            SPDK_DEBUGLOG("super_load for base bdev failed'%s'\n", base_info->name);
+            SPDK_DEBUGLOG("super_load for base bdev has failed'%s'\n", base_info->name);
             return rc;
         }
     }
@@ -1403,19 +1403,26 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
 
     rc = raid_bdev_base_bdev_super_validate(freshest, sb_recreate);
     if (rc) {
-        SPDK_DEBUGLOG("super_validate for freshest '%s' bdev have failed\n", base_info->name);
+        SPDK_DEBUGLOG("super_validate for freshest '%s' bdev has failed\n", base_info->name);
         return rc;
     }
 
     RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
         raid_bdev_base_bdev_super_validate(base_info, sb_recreate);
         if (rc) {
-            SPDK_DEBUGLOG("super_validate for '%s' bdev have failed\n", base_info.name);
+            SPDK_DEBUGLOG("super_validate for '%s' bdev has failed\n", base_info.name);
             return rc;
         }
     }
 
-    return rc;
+    RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
+        rc = raid_bdev_base_bdev_write_sb(base_info);
+        if (rc) {
+            SPDK_DEBUGLOG("Write superblock to '%s' bdev has failed");
+        }
+    }
+
+    return 0;
 }
 
 /*

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1285,6 +1285,8 @@ raid_bdev_super_init_validation(struct raid_bdev *raid, struct raid_base_bdev_in
     raid->strip_size = sb->strip_size;
     raid->strip_size_kb = sb->strip_size * sb->blocklen;
 
+    raid->is_new = false;
+
     return 0;
 }
 
@@ -1399,6 +1401,8 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
             return rc;
         }
     }
+
+    SPDK_DEBUGLOG(bdev_raid, "The freshest bdev is '%s'\n", freshest->name);
 
     if (!freshest) {
         SPDK_ERRLOG("There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1161,8 +1161,6 @@ raid_bdev_load_base_bdevs_sb(struct raid_base_bdev_info *base_info, uint32_t sb_
         return -ENOMEM;
     }
 
-    ctx = spdk_io_channel_get_ctx(ch);
-
     spdk_bdev_read_blocks(base_info->desc, ch, base_info->raid_sb, 0,
                           sb_size, (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_read_sb_compete,
                           base_info);
@@ -1219,17 +1217,9 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
         base_info->is_new = true;
 
     if (base_info->is_new) {
-        rc = raid_bdev_base_bdev_super_sync(base_info);
-        if (rc) {
-            SPDK_ERRLOG("Failed in super_sync for base bdev '%s'\n", base_info->name);
-            goto bad;
-        }
-
         *freshest = *freshest ? : base_info;
         return 0;
     }
-
-    base_info->raid_bdev->is_new = false;
 
     if (!*freshest) {
         *freshest = base_info;

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -795,10 +795,10 @@ static struct {
 	{ }
 };
 
-bool
-raid_bdev_is_raid_level(uint32_t level) {
+static bool
+raid_bdev_is_raid_level(int32_t level) {
     for (int i = 0; g_raid_level_names[i].name != NULL; i++) {
-        if (level == g_raid_level_names[i].value)
+        if (level == (int32_t) g_raid_level_names[i].value)
             return true;
     }
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -221,6 +221,9 @@ raid_bdev_free_base_bdev_resource(struct raid_base_bdev_info *base_info)
 	free(base_info->name);
 	base_info->name = NULL;
 
+    free(base_info->raid_sb);
+    base_info->raid_sb = NULL;
+
 	if (base_info->desc == NULL) {
 		return;
 	}

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -997,6 +997,7 @@ raid_bdev_module_init(struct raid_bdev *raid_bdev) {
     }
 
     raid_bdev->min_base_bdevs_operational = min_operational;
+    raid_bdev->module = module;
 
     return 0;
 }

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1887,7 +1887,8 @@ raid_bdev_configure_base_bdev(struct raid_base_bdev_info *base_info)
 
 	if (raid_bdev->superblock_enabled) {
 		assert((RAID_BDEV_MIN_DATA_OFFSET_SIZE % bdev->blocklen) == 0);
-		base_info->data_offset = RAID_BDEV_MIN_DATA_OFFSET_SIZE / bdev->blocklen;
+		base_info->data_offset = spdk_max(RAID_BDEV_MIN_DATA_OFFSET_SIZE/bdev->blocklen,
+                                          RAID_SB_BLOCKS(bdev->blocklen));
 
 		if (bdev->optimal_io_boundary) {
 			base_info->data_offset = spdk_divide_round_up(base_info->data_offset,

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1500,13 +1500,19 @@ raid_bdev_configure(struct raid_bdev *raid_bdev)
 	}
 
     if (raid_bdev->superblock_enabled) {
+        bool recreate = raid_bdev->is_new;
+
         /* majoranta for superblock metadata configuration */
         raid_bdev_gen->blockcnt = blocklen * raid_bdev->num_base_bdevs;
 
-        rc = raid_bdev_analyse_superblocks(raid_bdev, raid_bdev->is_new);
+        rc = raid_bdev_analyse_superblocks(raid_bdev, recreate);
         if (rc != 0) {
             SPDK_ERRLOG("raid module superblock analyse failed\n");
             return rc;
+        }
+
+        if (!recreate && raid_bdev_module_init(raid_bdev)) {
+            return -EINVAL;
         }
     }
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1141,7 +1141,7 @@ raid_bdev_configure_md(struct raid_bdev *raid_bdev)
 	return 0;
 }
 
-static int
+static void
 raid_bdev_base_bdev_write_sb_compete(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
     struct raid_base_bdev_info *base_info = cb_arg;
 
@@ -1176,7 +1176,7 @@ raid_bdev_base_bdev_write_sb(struct raid_base_bdev_info *base_info)
     return rc;
 }
 
-static int
+static void
 raid_bdev_base_bdev_read_sb_compete(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
     struct raid_base_bdev_info *base_info = cb_arg;
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1400,13 +1400,13 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
     RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
         rc = raid_bdev_base_bdev_super_load(base_info, &freshest);
         if (rc) {
-            SPDK_DEBUGLOG("super_load for base bdev has failed'%s'\n", base_info->name);
+            SPDK_DEBUGLOG(bdev_raid, "super_load for base bdev has failed'%s'\n", base_info->name);
             return rc;
         }
     }
 
     if (!freshest) {
-        SPDK_DEBUGLOG("There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);
+        SPDK_DEBUGLOG(bdev_raid, "There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);
         return 0;
     }
 
@@ -1414,14 +1414,14 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
 
     rc = raid_bdev_base_bdev_super_validate(freshest, sb_recreate);
     if (rc) {
-        SPDK_DEBUGLOG("super_validate for freshest '%s' bdev has failed\n", base_info->name);
+        SPDK_DEBUGLOG(bdev_raid, "super_validate for freshest '%s' bdev has failed\n", base_info->name);
         return rc;
     }
 
     RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
         raid_bdev_base_bdev_super_validate(base_info, sb_recreate);
         if (rc) {
-            SPDK_DEBUGLOG("super_validate for '%s' bdev has failed\n", base_info.name);
+            SPDK_DEBUGLOG(bdev_raid, "super_validate for '%s' bdev has failed\n", base_info->name);
             return rc;
         }
     }
@@ -1429,7 +1429,7 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
     RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
         rc = raid_bdev_base_bdev_write_sb(base_info);
         if (rc) {
-            SPDK_DEBUGLOG("Write superblock to '%s' bdev has failed");
+            SPDK_DEBUGLOG(bdev_raid, "Write superblock to '%s' bdev has failed\n", base_info->name);
         }
     }
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -221,8 +221,8 @@ raid_bdev_free_base_bdev_resource(struct raid_base_bdev_info *base_info)
 	free(base_info->name);
 	base_info->name = NULL;
 
-    spdk_dma_free(base_info->raid_sb);
-    base_info->raid_sb = NULL;
+	spdk_dma_free(base_info->raid_sb);
+	base_info->raid_sb = NULL;
 
 	if (base_info->desc == NULL) {
 		return;
@@ -797,12 +797,12 @@ static struct {
 
 static bool
 raid_bdev_is_raid_level(int32_t level) {
-    for (int i = 0; g_raid_level_names[i].name != NULL; i++) {
-        if (level == (int32_t) g_raid_level_names[i].value)
-            return true;
-    }
+	for (int i = 0; g_raid_level_names[i].name != NULL; i++) {
+		if (level == (int32_t) g_raid_level_names[i].value)
+			return true;
+	}
 
-    return false;
+	return false;
 }
 
 /* We have to use the typedef in the function declaration to appease astyle. */
@@ -951,55 +951,55 @@ raid_bdev_init(void)
 
 static int
 raid_bdev_module_init(struct raid_bdev *raid_bdev) {
-    struct raid_bdev_module *module;
-    uint8_t min_operational;
+	struct raid_bdev_module *module;
+	uint8_t min_operational;
 
-    module = raid_bdev_module_find(raid_bdev->level);
-    if (module == NULL) {
-        SPDK_ERRLOG("Unsupported raid_bdev level '%d'\n", raid_bdev->level);
-        return -EINVAL;
-    }
+	module = raid_bdev_module_find(raid_bdev->level);
+	if (module == NULL) {
+		SPDK_ERRLOG("Unsupported raid_bdev level '%d'\n", raid_bdev->level);
+		return -EINVAL;
+	}
 
-    assert(module->base_bdevs_min != 0);
-    if (raid_bdev->num_base_bdevs < module->base_bdevs_min) {
-        SPDK_ERRLOG("At least %u base devices required for %s\n",
-                    module->base_bdevs_min,
-                    raid_bdev_level_to_str(raid_bdev->level));
-        return -EINVAL;
-    }
+	assert(module->base_bdevs_min != 0);
+	if (raid_bdev->num_base_bdevs < module->base_bdevs_min) {
+		SPDK_ERRLOG("At least %u base devices required for %s\n",
+					module->base_bdevs_min,
+					raid_bdev_level_to_str(raid_bdev->level));
+		return -EINVAL;
+	}
 
-    switch (module->base_bdevs_constraint.type) {
-        case CONSTRAINT_MAX_BASE_BDEVS_REMOVED:
-            min_operational = raid_bdev->num_base_bdevs - module->base_bdevs_constraint.value;
-            break;
-        case CONSTRAINT_MIN_BASE_BDEVS_OPERATIONAL:
-            min_operational = module->base_bdevs_constraint.value;
-            break;
-        case CONSTRAINT_UNSET:
-            if (module->base_bdevs_constraint.value != 0) {
-                SPDK_ERRLOG("Unexpected constraint value '%u' provided for raid_bdev bdev '%s'.\n",
-                            (uint8_t)module->base_bdevs_constraint.value, raid_bdev->bdev.name);
-                return -EINVAL;
-            }
-            min_operational = raid_bdev->num_base_bdevs;
-            break;
-        default:
-            SPDK_ERRLOG("Unrecognised constraint type '%u' in module for raid_bdev level '%s'.\n",
-                        (uint8_t)module->base_bdevs_constraint.type,
-                        raid_bdev_level_to_str(module->level));
-            return -EINVAL;
-    }
+	switch (module->base_bdevs_constraint.type) {
+		case CONSTRAINT_MAX_BASE_BDEVS_REMOVED:
+			min_operational = raid_bdev->num_base_bdevs - module->base_bdevs_constraint.value;
+			break;
+		case CONSTRAINT_MIN_BASE_BDEVS_OPERATIONAL:
+			min_operational = module->base_bdevs_constraint.value;
+			break;
+		case CONSTRAINT_UNSET:
+			if (module->base_bdevs_constraint.value != 0) {
+				SPDK_ERRLOG("Unexpected constraint value '%u' provided for raid_bdev bdev '%s'.\n",
+							(uint8_t)module->base_bdevs_constraint.value, raid_bdev->bdev.name);
+				return -EINVAL;
+			}
+			min_operational = raid_bdev->num_base_bdevs;
+			break;
+		default:
+			SPDK_ERRLOG("Unrecognised constraint type '%u' in module for raid_bdev level '%s'.\n",
+						(uint8_t)module->base_bdevs_constraint.type,
+						raid_bdev_level_to_str(module->level));
+			return -EINVAL;
+	}
 
-    if (min_operational == 0 || min_operational > raid_bdev->num_base_bdevs) {
-        SPDK_ERRLOG("Wrong constraint value for raid_bdev level '%s'.\n",
-                    raid_bdev_level_to_str(module->level));
-        return -EINVAL;
-    }
+	if (min_operational == 0 || min_operational > raid_bdev->num_base_bdevs) {
+		SPDK_ERRLOG("Wrong constraint value for raid_bdev level '%s'.\n",
+					raid_bdev_level_to_str(module->level));
+		return -EINVAL;
+	}
 
-    raid_bdev->min_base_bdevs_operational = min_operational;
-    raid_bdev->module = module;
+	raid_bdev->min_base_bdevs_operational = min_operational;
+	raid_bdev->module = module;
 
-    return 0;
+	return 0;
 }
 
 /*
@@ -1069,12 +1069,12 @@ raid_bdev_create(const char *name, uint32_t strip_size, uint8_t num_base_bdevs,
 	raid_bdev->state = RAID_BDEV_STATE_CONFIGURING;
 	raid_bdev->level = level;
 	raid_bdev->superblock_enabled = superblock_enabled;
-    raid_bdev->is_new = true;
+	raid_bdev->is_new = true;
 
-    if (raid_bdev_module_init(raid_bdev)) {
-        raid_bdev_free(raid_bdev);
-        return -EINVAL;
-    }
+	if (raid_bdev_module_init(raid_bdev)) {
+		raid_bdev_free(raid_bdev);
+		return -EINVAL;
+	}
 
 	raid_bdev_gen = &raid_bdev->bdev;
 
@@ -1144,254 +1144,254 @@ raid_bdev_configure_md(struct raid_bdev *raid_bdev)
 
 static void
 raid_bdev_base_bdev_write_sb_compete(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
-    struct raid_base_bdev_info *base_info = cb_arg;
+	struct raid_base_bdev_info *base_info = cb_arg;
 
-    if (success) {
-        SPDK_DEBUGLOG(bdev_raid, "Write superblock to base bdev : '%s'\n", base_info->name);
-    } else {
-        SPDK_ERRLOG("Base bdev '%s' superblock io write has failed\n", base_info->name);
-    }
+	if (success) {
+		SPDK_DEBUGLOG(bdev_raid, "Write superblock to base bdev : '%s'\n", base_info->name);
+	} else {
+		SPDK_ERRLOG("Base bdev '%s' superblock io write has failed\n", base_info->name);
+	}
 
-    spdk_bdev_free_io(bdev_io);
+	spdk_bdev_free_io(bdev_io);
 }
 
 static int
 raid_bdev_base_bdev_write_sb(struct raid_base_bdev_info *base_info)
 {
-    int rc = 0;
-    struct spdk_io_channel *ch;
+	int rc = 0;
+	struct spdk_io_channel *ch;
 
-    ch = spdk_bdev_get_io_channel(base_info->desc);
+	ch = spdk_bdev_get_io_channel(base_info->desc);
 
-    if (!ch) {
-        SPDK_ERRLOG("Unable to create io channel for bdev '%s'\n", base_info->name);
-        return -ENOMEM;
-    }
+	if (!ch) {
+		SPDK_ERRLOG("Unable to create io channel for bdev '%s'\n", base_info->name);
+		return -ENOMEM;
+	}
 
-    rc = spdk_bdev_write_blocks(base_info->desc, ch, base_info->raid_sb, 0,
-                           RAID_SB_BLOCKS(spdk_bdev_desc_get_bdev(base_info->desc)->blocklen),
-                           (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_write_sb_compete,
-                          base_info);
+	rc = spdk_bdev_write_blocks(base_info->desc, ch, base_info->raid_sb, 0,
+						   RAID_SB_BLOCKS(spdk_bdev_desc_get_bdev(base_info->desc)->blocklen),
+						   (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_write_sb_compete,
+						  base_info);
 
-    spdk_put_io_channel(ch);
-    return rc;
+	spdk_put_io_channel(ch);
+	return rc;
 }
 
 static void
 raid_bdev_base_bdev_read_sb_compete(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
-    struct raid_base_bdev_info *base_info = cb_arg;
+	struct raid_base_bdev_info *base_info = cb_arg;
 
-    if (success) {
-        SPDK_DEBUGLOG(bdev_raid, "Read superblock from base bdev : '%s'\n", base_info->name);
-    } else {
-        SPDK_ERRLOG("base bdev '%s' superblock io read has failed\n", base_info->name);
-    }
+	if (success) {
+		SPDK_DEBUGLOG(bdev_raid, "Read superblock from base bdev : '%s'\n", base_info->name);
+	} else {
+		SPDK_ERRLOG("base bdev '%s' superblock io read has failed\n", base_info->name);
+	}
 
-    spdk_bdev_free_io(bdev_io);
+	spdk_bdev_free_io(bdev_io);
 }
 
 static int
 raid_bdev_base_bdev_read_sb(struct raid_base_bdev_info *base_info, uint32_t sb_size)
 {
-    int rc = 0;
-    struct spdk_io_channel *ch;
+	int rc = 0;
+	struct spdk_io_channel *ch;
 
-    ch = spdk_bdev_get_io_channel(base_info->desc);
+	ch = spdk_bdev_get_io_channel(base_info->desc);
 
-    if (!ch) {
-        SPDK_ERRLOG("Unable to create io channel for bdev '%s'\n", base_info->name);
-        return -ENOMEM;
-    }
+	if (!ch) {
+		SPDK_ERRLOG("Unable to create io channel for bdev '%s'\n", base_info->name);
+		return -ENOMEM;
+	}
 
-    rc = spdk_bdev_read_blocks(base_info->desc, ch, base_info->raid_sb, 0,
-                          sb_size, (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_read_sb_compete,
-                          base_info);
-
-    spdk_put_io_channel(ch);
-    return rc;
+	rc = spdk_bdev_read_blocks(base_info->desc, ch, base_info->raid_sb, 0,
+						  sb_size, (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_read_sb_compete,
+						  base_info);
+//    wait(NULL);
+	spdk_put_io_channel(ch);
+	return rc;
 }
 
 static int
 raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct raid_base_bdev_info **freshest)
 {
-    int rc = 0;
-    struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
+	int rc = 0;
+	struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
 
-    base_info->raid_sb = spdk_dma_malloc(RAID_SB_BLOCKS(base_bdev->blocklen) * base_bdev->blocklen, 0, NULL);
-    if (!base_info->raid_sb) {
-        SPDK_ERRLOG("Failed to allocate memory for raid_sb\n");
-        return -ENOMEM;
-    }
+	base_info->raid_sb = spdk_dma_malloc(RAID_SB_BLOCKS(base_bdev->blocklen) * base_bdev->blocklen, 0, NULL);
+	if (!base_info->raid_sb) {
+		SPDK_ERRLOG("Failed to allocate memory for raid_sb\n");
+		return -ENOMEM;
+	}
 
-    rc = raid_bdev_base_bdev_read_sb(base_info, RAID_SB_BLOCKS(base_bdev->blocklen));
-    if (rc) {
-        SPDK_ERRLOG("Failed while read superblock from base bdev '%s'\n", base_info->name);
-        return rc;
-    }
+	rc = raid_bdev_base_bdev_read_sb(base_info, RAID_SB_BLOCKS(base_bdev->blocklen));
+	if (rc) {
+		SPDK_ERRLOG("Failed while read superblock from base bdev '%s'\n", base_info->name);
+		return rc;
+	}
 
-    struct raid_superblock *sb = base_info->raid_sb;
+	struct raid_superblock *sb = base_info->raid_sb;
 
-    if (sb->magic != RAID_SUPERBLOCK_MAGIC)
-        base_info->is_new = true;
+	if (sb->magic != RAID_SUPERBLOCK_MAGIC)
+		base_info->is_new = true;
 
-    if (base_info->is_new) {
-        *freshest = *freshest ? : base_info;
-        return 0;
-    }
+	if (base_info->is_new) {
+		*freshest = *freshest ? : base_info;
+		return 0;
+	}
 
-    if (!*freshest) {
-        *freshest = base_info;
-        return 0;
-    }
+	if (!*freshest) {
+		*freshest = base_info;
+		return 0;
+	}
 
-    if ((*freshest)->raid_sb->timestamp.tv_sec <= sb->timestamp.tv_sec &&
-        (*freshest)->raid_sb->timestamp.tv_nsec < sb->timestamp.tv_nsec)
-        *freshest = base_info;
+	if ((*freshest)->raid_sb->timestamp.tv_sec <= sb->timestamp.tv_sec &&
+		(*freshest)->raid_sb->timestamp.tv_nsec < sb->timestamp.tv_nsec)
+		*freshest = base_info;
 
-    return 0;
+	return 0;
 }
 
 static int
 raid_bdev_super_init_validation(struct raid_bdev *raid, struct raid_base_bdev_info *base_info)
 {
-    struct raid_superblock *sb = base_info->raid_sb;
+	struct raid_superblock *sb = base_info->raid_sb;
 
-    assert(raid->num_base_bdevs == raid->num_base_bdevs_discovered);
+	assert(raid->num_base_bdevs == raid->num_base_bdevs_discovered);
 
-    if (base_info->is_new) {
-        SPDK_ERRLOG("There isn't any metadata on base bdevs for raid '%s'\n", raid->bdev.name);
-        return -EINVAL;
-    }
+	if (base_info->is_new) {
+		SPDK_ERRLOG("There isn't any metadata on base bdevs for raid '%s'\n", raid->bdev.name);
+		return -EINVAL;
+	}
 
-    if (sb->version != RAID_METADATA_VERSION_01) {
-        SPDK_ERRLOG("Unsupported version of raid metadata has been found in base '%s' bdev's superblock\n",
-                    base_info->name);
-        return -EINVAL;
-    }
+	if (sb->version != RAID_METADATA_VERSION_01) {
+		SPDK_ERRLOG("Unsupported version of raid metadata has been found in base '%s' bdev's superblock\n",
+					base_info->name);
+		return -EINVAL;
+	}
 
-    if (sb->num_base_bdevs != raid->num_base_bdevs) {
-        SPDK_ERRLOG("The '%s' bdev's number of devices isn't equal to RAID's\n",
-                    base_info->name);
-        return -EINVAL;
-    }
+	if (sb->num_base_bdevs != raid->num_base_bdevs) {
+		SPDK_ERRLOG("The '%s' bdev's number of devices isn't equal to RAID's\n",
+					base_info->name);
+		return -EINVAL;
+	}
 
-    if (!raid_bdev_is_raid_level(sb->level)) {
-        SPDK_ERRLOG("Invalid RAID level in base '%s' bdev's metadata. Retrieving of array isn't possible\n",
-                    base_info->name);
-        return -EINVAL;
-    }
+	if (!raid_bdev_is_raid_level(sb->level)) {
+		SPDK_ERRLOG("Invalid RAID level in base '%s' bdev's metadata. Retrieving of array isn't possible\n",
+					base_info->name);
+		return -EINVAL;
+	}
 
-    raid->num_base_bdevs = sb->num_base_bdevs;
-    raid->num_base_bdevs_discovered = sb->num_base_bdevs;
-    raid->level = sb->level;
-    raid->bdev.blocklen = sb->blocklen;
-    raid->bdev.blockcnt = sb->raid_blockcnt;
-    spdk_uuid_copy(&raid->bdev.uuid, &sb->uuid);
-    raid->strip_size = sb->strip_size;
-    raid->strip_size_kb = sb->strip_size * sb->blocklen;
-    raid->strip_size_shift = spdk_u32log2(sb->strip_size);
-    raid->blocklen_shift = spdk_u32log2(sb->blocklen);
+	raid->num_base_bdevs = sb->num_base_bdevs;
+	raid->num_base_bdevs_discovered = sb->num_base_bdevs;
+	raid->level = sb->level;
+	raid->bdev.blocklen = sb->blocklen;
+	raid->bdev.blockcnt = sb->raid_blockcnt;
+	spdk_uuid_copy(&raid->bdev.uuid, &sb->uuid);
+	raid->strip_size = sb->strip_size;
+	raid->strip_size_kb = sb->strip_size * sb->blocklen;
+	raid->strip_size_shift = spdk_u32log2(sb->strip_size);
+	raid->blocklen_shift = spdk_u32log2(sb->blocklen);
 
-    raid->is_new = false;
+	raid->is_new = false;
 
-    return 0;
+	return 0;
 }
 
 static int
 raid_bdev_base_bdev_super_sync(struct raid_base_bdev_info *base_info)
 {
-    struct raid_superblock *sb = base_info->raid_sb;
-    struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
-    struct raid_bdev *raid = base_info->raid_bdev;
+	struct raid_superblock *sb = base_info->raid_sb;
+	struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
+	struct raid_bdev *raid = base_info->raid_bdev;
 
-    sb->magic = RAID_SUPERBLOCK_MAGIC;
-    sb->version = RAID_METADATA_VERSION_01;
-    sb->blocklen = raid->bdev.blocklen;
-    sb->num_base_bdevs = raid->num_base_bdevs;
-    sb->level = raid->level;
-    sb->array_position = base_info->position;
-    sb->strip_size = raid->strip_size;
-    sb->raid_blockcnt = raid->bdev.blockcnt;
-    spdk_uuid_copy(&sb->uuid, &raid->bdev.uuid);
+	sb->magic = RAID_SUPERBLOCK_MAGIC;
+	sb->version = RAID_METADATA_VERSION_01;
+	sb->blocklen = raid->bdev.blocklen;
+	sb->num_base_bdevs = raid->num_base_bdevs;
+	sb->level = raid->level;
+	sb->array_position = base_info->position;
+	sb->strip_size = raid->strip_size;
+	sb->raid_blockcnt = raid->bdev.blockcnt;
+	spdk_uuid_copy(&sb->uuid, &raid->bdev.uuid);
 
-    memset(sb+1, 0, RAID_SB_BLOCKS(base_bdev->blocklen));
+	memset(sb+1, 0, RAID_SB_BLOCKS(base_bdev->blocklen));
 
-    return 0;
+	return 0;
 }
 
 static int
 raid_bdev_base_bdev_capture_super_validate(struct raid_base_bdev_info *base_info) {
-    struct raid_superblock *sb = base_info->raid_sb;
-    struct raid_bdev *raid = base_info->raid_bdev;
+	struct raid_superblock *sb = base_info->raid_sb;
+	struct raid_bdev *raid = base_info->raid_bdev;
 
-    /* The absence of a rebuild does not allow to capture not SPDK RAID disks or disks from the another RAID now.
-     * Redo when the rebuild will be done.
-     */
-    if (base_info->is_new) {
-        SPDK_ERRLOG("The bdev '%s' haven't been in a SPDK RAID\n",
-                    base_info->name);
-        return -EINVAL;
-    } else if (spdk_uuid_compare(&sb->uuid, &raid->bdev.uuid)) {
-        SPDK_ERRLOG("The bdev '%s' have been in another RAID bdev\n",
-                    base_info->name);
-        return -EINVAL;
-    }
+	/* The absence of a rebuild does not allow to capture not SPDK RAID disks or disks from the another RAID now.
+	 * Redo when the rebuild will be done.
+	 */
+	if (base_info->is_new) {
+		SPDK_ERRLOG("The bdev '%s' haven't been in a SPDK RAID\n",
+					base_info->name);
+		return -EINVAL;
+	} else if (spdk_uuid_compare(&sb->uuid, &raid->bdev.uuid)) {
+		SPDK_ERRLOG("The bdev '%s' have been in another RAID bdev\n",
+					base_info->name);
+		return -EINVAL;
+	}
 
-    if (sb->array_position != base_info->position) {
-        SPDK_WARNLOG("The base bdev '%s' has changed position in the raid from '%n' to '%n'\n", base_info->name,
-                     &sb->array_position, &base_info->position);
-    }
+	if (sb->array_position != base_info->position) {
+		SPDK_WARNLOG("The base bdev '%s' has changed position in the raid from '%n' to '%n'\n", base_info->name,
+					 &sb->array_position, &base_info->position);
+	}
 
-    if (sb->blocklen != raid->bdev.blocklen) {
-        SPDK_ERRLOG("The logical block length stored in metadata of base '%s' bdev differ from RAID block length\n",
-                    base_info->name);
-        return -EINVAL;
-    }
+	if (sb->blocklen != raid->bdev.blocklen) {
+		SPDK_ERRLOG("The logical block length stored in metadata of base '%s' bdev differ from RAID block length\n",
+					base_info->name);
+		return -EINVAL;
+	}
 
-    if (sb->strip_size != raid->strip_size) {
-        SPDK_WARNLOG("The strip size stored in metadata of base '%s' bdev differ from RAID strip size and"
-                     "it will be overwritten\n", base_info->name);
-    }
+	if (sb->strip_size != raid->strip_size) {
+		SPDK_WARNLOG("The strip size stored in metadata of base '%s' bdev differ from RAID strip size and"
+					 "it will be overwritten\n", base_info->name);
+	}
 
-    return 0;
+	return 0;
 }
 
 static int
 raid_bdev_base_bdev_super_init(struct raid_base_bdev_info *base_info) {
-    struct raid_superblock *sb = base_info->raid_sb;
-    struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
-    struct timespec time_0 = {.tv_nsec = 0, .tv_sec = 0};
+	struct raid_superblock *sb = base_info->raid_sb;
+	struct spdk_bdev *base_bdev = spdk_bdev_desc_get_bdev(base_info->desc);
+	struct timespec time_0 = {.tv_nsec = 0, .tv_sec = 0};
 
-    sb->blockcnt = base_bdev->blockcnt;
-    sb->timestamp = time_0;
+	sb->blockcnt = base_bdev->blockcnt;
+	sb->timestamp = time_0;
 
-    return 0;
+	return 0;
 }
 
 static int
 raid_bdev_base_bdev_super_validate(struct raid_base_bdev_info *base_info, bool recreate)
 {
-    int rc = 0;
-    struct raid_superblock *sb = base_info->raid_sb;
-    struct raid_bdev *raid = base_info->raid_bdev;
+	int rc = 0;
+	struct raid_superblock *sb = base_info->raid_sb;
+	struct raid_bdev *raid = base_info->raid_bdev;
 
-    if (raid->num_base_bdevs <= 0 || !sb)
-        return 0;
+	if (raid->num_base_bdevs <= 0 || !sb)
+		return 0;
 
-    if (!recreate && raid->is_new && raid_bdev_super_init_validation(raid, base_info))
-        return -EINVAL;
+	if (!recreate && raid->is_new && raid_bdev_super_init_validation(raid, base_info))
+		return -EINVAL;
 
-    if (!raid->is_new || recreate) {
-        if (!recreate && raid_bdev_base_bdev_capture_super_validate(base_info))
-            return -EINVAL;
-        
-        raid_bdev_base_bdev_super_sync(base_info);
+	if (!raid->is_new || recreate) {
+		if (!recreate && raid_bdev_base_bdev_capture_super_validate(base_info))
+			return -EINVAL;
 
-        if (recreate)
-            raid_bdev_base_bdev_super_init(base_info);
-    }
+		raid_bdev_base_bdev_super_sync(base_info);
 
-    return rc;
+		if (recreate)
+			raid_bdev_base_bdev_super_init(base_info);
+	}
+
+	return rc;
 }
 
 /*
@@ -1412,8 +1412,8 @@ raid_bdev_configure(struct raid_bdev *raid_bdev)
 	struct spdk_bdev *raid_bdev_gen;
 	struct raid_base_bdev_info *base_info;
 	struct spdk_bdev *base_bdev;
-    bool sb_recreate = raid_bdev->is_new;
-    struct raid_base_bdev_info *freshest = NULL;
+	bool sb_recreate = raid_bdev->is_new;
+	struct raid_base_bdev_info *freshest = NULL;
 	int rc = 0;
 
 	assert(raid_bdev->state == RAID_BDEV_STATE_CONFIGURING);
@@ -1456,34 +1456,34 @@ raid_bdev_configure(struct raid_bdev *raid_bdev)
 		return rc;
 	}
 
-    if (raid_bdev->superblock_enabled) {
-        RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
-            rc = raid_bdev_base_bdev_super_load(base_info, &freshest);
-            if (rc) {
-                SPDK_DEBUGLOG(bdev_raid, "super_load for base bdev has failed'%s'\n", base_info->name);
-                return rc;
-            }
-        }
+	if (raid_bdev->superblock_enabled) {
+		RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
+			rc = raid_bdev_base_bdev_super_load(base_info, &freshest);
+			if (rc) {
+				SPDK_DEBUGLOG(bdev_raid, "super_load for base bdev has failed'%s'\n", base_info->name);
+				return rc;
+			}
+		}
 
-        SPDK_DEBUGLOG(bdev_raid, "The freshest bdev is '%s'\n", freshest->name);
+		SPDK_DEBUGLOG(bdev_raid, "The freshest bdev is '%s'\n", freshest->name);
 
-        if (!freshest) {
-            SPDK_ERRLOG("There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);
-            return -EINVAL;
-        }
+		if (!freshest) {
+			SPDK_ERRLOG("There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);
+			return -EINVAL;
+		}
 
-        raid_bdev->is_new = true;
+		raid_bdev->is_new = true;
 
-        rc = raid_bdev_base_bdev_super_validate(freshest, sb_recreate);
-        if (rc) {
-            SPDK_DEBUGLOG(bdev_raid, "super_validate for freshest '%s' bdev has failed\n", base_info->name);
-            return rc;
-        }
+		rc = raid_bdev_base_bdev_super_validate(freshest, sb_recreate);
+		if (rc) {
+			SPDK_DEBUGLOG(bdev_raid, "super_validate for freshest '%s' bdev has failed\n", base_info->name);
+			return rc;
+		}
 
-        if (!sb_recreate && raid_bdev_module_init(raid_bdev)) {
-            return -EINVAL;
-        }
-    }
+		if (!sb_recreate && raid_bdev_module_init(raid_bdev)) {
+			return -EINVAL;
+		}
+	}
 
 	rc = raid_bdev->module->start(raid_bdev);
 	if (rc != 0) {
@@ -1511,22 +1511,22 @@ raid_bdev_configure(struct raid_bdev *raid_bdev)
 	SPDK_DEBUGLOG(bdev_raid, "raid bdev is created with name %s, raid_bdev %p\n",
 		      raid_bdev_gen->name, raid_bdev);
 
-    if (raid_bdev->superblock_enabled) {
-        RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
-            raid_bdev_base_bdev_super_validate(base_info, sb_recreate);
-            if (rc) {
-                SPDK_DEBUGLOG(bdev_raid, "super_validate for '%s' bdev has failed\n", base_info->name);
-                return rc;
-            }
-        }
+	if (raid_bdev->superblock_enabled) {
+		RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
+			raid_bdev_base_bdev_super_validate(base_info, sb_recreate);
+			if (rc) {
+				SPDK_DEBUGLOG(bdev_raid, "super_validate for '%s' bdev has failed\n", base_info->name);
+				return rc;
+			}
+		}
 
-        RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
-            rc = raid_bdev_base_bdev_write_sb(base_info);
-            if (rc) {
-                SPDK_DEBUGLOG(bdev_raid, "Write superblock to '%s' bdev has failed\n", base_info->name);
-            }
-        }
-    }
+		RAID_FOR_EACH_BASE_BDEV(raid_bdev, base_info) {
+			rc = raid_bdev_base_bdev_write_sb(base_info);
+			if (rc) {
+				SPDK_DEBUGLOG(bdev_raid, "Write superblock to '%s' bdev has failed\n", base_info->name);
+			}
+		}
+	}
 
 	return 0;
 }
@@ -1891,7 +1891,7 @@ raid_bdev_configure_base_bdev(struct raid_base_bdev_info *base_info)
 	if (raid_bdev->superblock_enabled) {
 		assert((RAID_BDEV_MIN_DATA_OFFSET_SIZE % bdev->blocklen) == 0);
 		base_info->data_offset = spdk_max(RAID_BDEV_MIN_DATA_OFFSET_SIZE/bdev->blocklen,
-                                          RAID_SB_BLOCKS(bdev->blocklen));
+										  RAID_SB_BLOCKS(bdev->blocklen));
 
 		if (bdev->optimal_io_boundary) {
 			base_info->data_offset = spdk_divide_round_up(base_info->data_offset,
@@ -1900,7 +1900,7 @@ raid_bdev_configure_base_bdev(struct raid_base_bdev_info *base_info)
 
 		if (base_info->data_offset >= bdev->blockcnt) {
 			SPDK_ERRLOG("Data offset %lu exceeds base bdev capacity %lu on bdev '%s'\n",
-				    base_info->data_offset, bdev->blockcnt, base_info->name);
+					base_info->data_offset, bdev->blockcnt, base_info->name);
 			return -EINVAL;
 		}
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1281,7 +1281,7 @@ raid_bdev_super_init_validation(struct raid_bdev *raid, struct raid_base_bdev_in
     raid->level = sb->level;
     raid->bdev.blocklen = sb->blocklen;
     raid->bdev.blockcnt = sb->raid_blockcnt;
-    raid->bdev.uuid = sb->uuid;
+    spdk_uuid_copy(&raid->bdev.uuid, &sb->uuid);
     raid->strip_size = sb->strip_size;
     raid->strip_size_kb = sb->strip_size * sb->blocklen;
 
@@ -1303,7 +1303,7 @@ raid_bdev_base_bdev_super_sync(struct raid_base_bdev_info *base_info)
     sb->array_position = base_info->position;
     sb->strip_size = raid->strip_size;
     sb->raid_blockcnt = raid->bdev.blockcnt;
-    sb->uuid = raid->bdev.uuid;
+    spdk_uuid_copy(&sb->uuid, &raid->bdev.uuid);
 
     memset(sb+1, 0, RAID_SB_BLOCKS(base_bdev->blocklen));
 

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1199,7 +1199,7 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
     rc = raid_bdev_load_base_bdevs_sb(base_info, sb_blocks);
     if (rc) {
         SPDK_ERRLOG("Failed while read superblock from base bdev '%s'\n", base_info->name);
-        goto clean;
+        goto bad;
     }
 
     struct raid_superblock *sb = base_info->raid_sb;
@@ -1211,7 +1211,7 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
         rc = raid_bdev_base_bdev_super_sync(base_info);
         if (rc) {
             SPDK_ERRLOG("Failed in super_sync for base bdev '%s'\n", base_info->name);
-            goto clean;
+            goto bad;
         }
 
         *freshest = *freshest ? : sb;
@@ -1226,9 +1226,7 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
     *freshest = (*freshest)->timestamp.tv_nsec > sb->timestamp.tv_nsec ? *freshest : sb;
     return 0;
 
-clean:
-    free(base_info->raid_sb);
-    base_info->raid_sb = NULL;
+bad:
     base_info->sb_loaded = false;
     return rc;
 }

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1168,7 +1168,7 @@ raid_bdev_base_bdev_write_sb(struct raid_base_bdev_info *base_info)
     }
 
     rc = spdk_bdev_write_blocks(base_info->desc, ch, base_info->raid_sb, 0,
-                           RAID_SB_BLOCKS(spdk_bdev_desc_get_bdev(base_info)->blocklen),
+                           RAID_SB_BLOCKS(spdk_bdev_desc_get_bdev(base_info->desc)->blocklen),
                            (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_write_sb_compete,
                           base_info);
 
@@ -1335,7 +1335,7 @@ raid_bdev_base_bdev_capture_super_validate(struct raid_base_bdev_info *base_info
 
     if (sb->array_position != base_info->position) {
         SPDK_WARNLOG("The base bdev '%s' has changed position in the raid from '%n' to '%n'\n", base_info->name,
-                 sb->array_position, base_info->position);
+                     &sb->array_position, &base_info->position);
     }
 
     if (sb->blocklen != raid->bdev.blocklen) {

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1134,9 +1134,9 @@ raid_bdev_base_bdev_read_sb_compete(struct spdk_bdev_io *bdev_io, bool success, 
     struct raid_base_bdev_info *base_info = cb_arg;
 
     if (success) {
-        SPDK_NOTICELOG("Read superblock from base bdev : %s\n", base_info->name);
+        SPDK_NOTICELOG("Read superblock from base bdev : '%s'\n", base_info->name);
     } else {
-        SPDK_ERRLOG("base bdev '%s' superblock io read error\n", base_info->name);
+        SPDK_ERRLOG("base bdev '%s' superblock io read has failed\n", base_info->name);
     }
 
     spdk_bdev_free_io(bdev_io);
@@ -1147,6 +1147,7 @@ raid_bdev_base_bdev_read_sb_compete(struct spdk_bdev_io *bdev_io, bool success, 
 static int
 raid_bdev_load_base_bdevs_sb(struct raid_base_bdev_info *base_info, uint32_t sb_size)
 {
+    int rc = 0;
     struct spdk_io_channel *ch;
     struct spdk_bdev_channel *ctx;
     struct spdk_bdev_io *bdev_io;
@@ -1161,10 +1162,12 @@ raid_bdev_load_base_bdevs_sb(struct raid_base_bdev_info *base_info, uint32_t sb_
         return -ENOMEM;
     }
 
-    spdk_bdev_read_blocks(base_info->desc, ch, base_info->raid_sb, 0,
+    rc = spdk_bdev_read_blocks(base_info->desc, ch, base_info->raid_sb, 0,
                           sb_size, (spdk_bdev_io_completion_cb) raid_bdev_base_bdev_read_sb_compete,
                           base_info);
-    return 0;
+
+    spdk_put_io_channel(ch);
+    return rc;
 }
 
 static int

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -1400,8 +1400,8 @@ raid_bdev_analyse_superblocks(struct raid_bdev *raid_bdev, bool sb_recreate)
     }
 
     if (!freshest) {
-        SPDK_DEBUGLOG(bdev_raid, "There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);
-        return 0;
+        SPDK_ERRLOG("There aren't base bdevs in raid bdev '%s'\n", raid_bdev->bdev.name);
+        return -EINVAL;
     }
 
     raid_bdev->is_new = true;

--- a/module/bdev/raid/bdev_raid.c
+++ b/module/bdev/raid/bdev_raid.c
@@ -988,7 +988,7 @@ raid_bdev_module_init(struct raid_bdev *raid_bdev) {
                         (uint8_t)module->base_bdevs_constraint.type,
                         raid_bdev_level_to_str(module->level));
             return -EINVAL;
-    };
+    }
 
     if (min_operational == 0 || min_operational > raid_bdev->num_base_bdevs) {
         SPDK_ERRLOG("Wrong constraint value for raid_bdev level '%s'.\n",
@@ -1159,7 +1159,6 @@ raid_bdev_base_bdev_write_sb(struct raid_base_bdev_info *base_info)
 {
     int rc = 0;
     struct spdk_io_channel *ch;
-    struct spdk_bdev_io *bdev_io;
 
     ch = spdk_bdev_get_io_channel(base_info->desc);
 
@@ -1197,7 +1196,6 @@ raid_bdev_base_bdev_read_sb(struct raid_base_bdev_info *base_info, uint32_t sb_s
 {
     int rc = 0;
     struct spdk_io_channel *ch;
-    struct spdk_bdev_io *bdev_io;
 
     if (base_info->sb_loaded)
         return 0;
@@ -1261,7 +1259,6 @@ raid_bdev_base_bdev_super_load(struct raid_base_bdev_info *base_info, struct rai
 static int
 raid_bdev_super_init_validation(struct raid_bdev *raid, struct raid_base_bdev_info *base_info)
 {
-    int rc = 0;
     struct raid_superblock *sb = base_info->raid_sb;
 
     assert(raid->num_base_bdevs == raid->num_base_bdevs_discovered);

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -108,6 +108,15 @@ struct raid_base_bdev_info {
 	/* pointer to base bdev descriptor opened by raid bdev */
 	struct spdk_bdev_desc	*desc;
 
+    /* position of the base bdev in raid_bdev's base_bdev_info (slot) */
+    uint32_t position;
+
+    /* indicate if the metadata was on disk or not */
+    bool is_new;
+
+    /* true if sb has loaded */
+    bool sb_loaded;
+
     /* base bdev's superblock */
     struct raid_superblock  *raid_sb;
 
@@ -189,6 +198,9 @@ struct raid_bdev {
 
 	/* state of raid bdev */
 	enum raid_bdev_state		state;
+
+    /* indicate if raid is new for raid_bdev_base_bdev_sb_validate */
+    bool                is_new;
 
 	/* number of base bdevs comprising raid bdev  */
 	uint8_t				num_base_bdevs;

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -63,19 +63,16 @@ struct raid_superblock {
     uint32_t        magic;
 
     /* The version of metadata. Currently, only 01 version exists */
-    enum metadata_version   version;
+    uint32_t        version;
 
     /* Logical block size of base bdev */
     uint32_t        blocklen;
-
-    /* Physical block size of base bdev */
-    uint32_t        phys_blocklen;
 
     /* Number of base bdevs */
     uint8_t         num_base_bdevs;
 
     /* Raid Level of device's raid */
-    enum raid_level level;
+    uint32_t        level;
 
     /* Position of device in raid */
     uint32_t        array_position;

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -200,7 +200,7 @@ struct raid_bdev {
 	/* state of raid bdev */
 	enum raid_bdev_state		state;
 
-    /* indicate if raid is new for raid_bdev_base_bdev_sb_validate */
+    /* indicate if raid is new for  */
     bool                is_new;
 
 	/* number of base bdevs comprising raid bdev  */

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -11,6 +11,8 @@
 
 #define RAID_BDEV_MIN_DATA_OFFSET_SIZE	(1024*1024) /* 1 MiB */
 
+#define RAID_SUPERBLOCK_MAGIC 0x534B5244 /* "SKRD" */
+
 enum raid_level {
 	INVALID_RAID_LEVEL	= -1,
 	RAID0			= 0,
@@ -45,19 +47,26 @@ enum raid_bdev_state {
 
 typedef void (*raid_bdev_remove_base_bdev_cb)(void *ctx, int status);
 
+enum metadata_version {
+    RAID_METADATA_VERSION_01 = 01
+};
+
 /*
  * Superblock for operation with metadata of the base bdev which part of some raid.
  * It stores some metadata of the base bdev and the raid
  */
 struct raid_superblock {
-    /* SPDK raid magic number "SKRd" */
+    /* SPDK raid magic number "SKRD" */
     uint32_t        magic;
 
     /* The version of metadata. Currently, only 01 version exists */
-    uint32_t        version;
+    enum metadata_version   version;
 
     /* Logical block size of base bdev */
     uint32_t        blocklen;
+
+    /* Physical block size of base bdev */
+    uint32_t        phys_blocklen;
 
     /* Number of base bdevs */
     uint8_t         num_base_bdevs;
@@ -80,7 +89,7 @@ struct raid_superblock {
     /* Timestamp to know the freshest device in raid */
     struct timespec timestamp;
 
-    /* UUID of this base bdev */
+    /* UUID of raid bdev */
     struct spdk_uuid uuid;
 };
 

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -72,7 +72,7 @@ struct raid_superblock {
     uint8_t         num_base_bdevs;
 
     /* Raid Level of device's raid */
-    uint32_t        level;
+    int32_t        level;
 
     /* Position of device in raid */
     uint32_t        array_position;
@@ -92,7 +92,7 @@ struct raid_superblock {
     /* UUID of raid bdev */
     struct spdk_uuid uuid;
 };
-#pragma pop
+#pragma pack(pop)
 
 /*
  * raid_base_bdev_info contains information for the base bdevs which are part of some

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -46,6 +46,45 @@ enum raid_bdev_state {
 typedef void (*raid_bdev_remove_base_bdev_cb)(void *ctx, int status);
 
 /*
+ * Superblock for operation with metadata of the base bdev which part of some raid.
+ * It stores some metadata of the base bdev and the raid
+ */
+struct raid_superblock {
+    /* SPDK raid magic number "SKRd" */
+    uint32_t        magic;
+
+    /* The version of metadata. Currently, only 01 version exists */
+    uint32_t        version;
+
+    /* Logical block size of base bdev */
+    uint32_t        blocklen;
+
+    /* Number of base bdevs */
+    uint8_t         num_base_bdevs;
+
+    /* Raid Level of device's raid */
+    enum raid_level level;
+
+    /* Position of device in raid */
+    uint32_t        array_position;
+
+    /* strip size of device's raid in blocks */
+    uint32_t        strip_size;
+
+    /* Number of blocks held by this base bdev */
+    uint64_t        blockcnt;
+
+    /* Number of blocks held by device's raid */
+    uint64_t        raid_blockcnt;
+
+    /* Timestamp to know the freshest device in raid */
+    struct timespec timestamp;
+
+    /* UUID of this base bdev */
+    struct spdk_uuid uuid;
+};
+
+/*
  * raid_base_bdev_info contains information for the base bdevs which are part of some
  * raid. This structure contains the per base bdev information. Whatever is
  * required per base device for raid bdev will be kept here
@@ -59,6 +98,9 @@ struct raid_base_bdev_info {
 
 	/* pointer to base bdev descriptor opened by raid bdev */
 	struct spdk_bdev_desc	*desc;
+
+    /* base bdev's superblock */
+    struct raid_superblock  *raid_sb;
 
 	/* offset in blocks from the start of the base bdev to the start of the data region */
 	uint64_t		data_offset;

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -53,6 +53,7 @@ enum metadata_version {
     RAID_METADATA_VERSION_01 = 01
 };
 
+#pragma pack(push, 1)
 /*
  * Superblock for operation with metadata of the base bdev which part of some raid.
  * It stores some metadata of the base bdev and the raid
@@ -94,6 +95,7 @@ struct raid_superblock {
     /* UUID of raid bdev */
     struct spdk_uuid uuid;
 };
+#pragma pop
 
 /*
  * raid_base_bdev_info contains information for the base bdevs which are part of some

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -50,7 +50,7 @@ enum raid_bdev_state {
 typedef void (*raid_bdev_remove_base_bdev_cb)(void *ctx, int status);
 
 enum metadata_version {
-    RAID_METADATA_VERSION_01 = 01
+	RAID_METADATA_VERSION_01 = 01
 };
 
 #pragma pack(push, 1)
@@ -59,38 +59,38 @@ enum metadata_version {
  * It stores some metadata of the base bdev and the raid
  */
 struct raid_superblock {
-    /* SPDK raid magic number "SKRD" */
-    uint32_t        magic;
+	/* SPDK raid magic number "SKRD" */
+	uint32_t		magic;
 
-    /* The version of metadata. Currently, only 01 version exists */
-    uint32_t        version;
+	/* The version of metadata. Currently, only 01 version exists */
+	uint32_t		version;
 
-    /* Logical block size of base bdev */
-    uint32_t        blocklen;
+	/* Logical block size of base bdev */
+	uint32_t		blocklen;
 
-    /* Number of base bdevs */
-    uint8_t         num_base_bdevs;
+	/* Number of base bdevs */
+	uint8_t			num_base_bdevs;
 
-    /* Raid Level of device's raid */
-    int32_t        level;
+	/* Raid Level of device's raid */
+	int32_t			level;
 
-    /* Position of device in raid */
-    uint32_t        array_position;
+	/* Position of device in raid */
+	uint32_t		array_position;
 
-    /* strip size of device's raid in blocks */
-    uint32_t        strip_size;
+	/* strip size of device's raid in blocks */
+	uint32_t		strip_size;
 
-    /* Number of blocks held by this base bdev */
-    uint64_t        blockcnt;
+	/* Number of blocks held by this base bdev */
+	uint64_t		blockcnt;
 
-    /* Number of blocks held by device's raid */
-    uint64_t        raid_blockcnt;
+	/* Number of blocks held by device's raid */
+	uint64_t		raid_blockcnt;
 
-    /* Timestamp to know the freshest device in raid */
-    struct timespec timestamp;
+	/* Timestamp to know the freshest device in raid */
+	struct timespec timestamp;
 
-    /* UUID of raid bdev */
-    struct spdk_uuid uuid;
+	/* UUID of raid bdev */
+	struct spdk_uuid uuid;
 };
 #pragma pack(pop)
 
@@ -109,14 +109,14 @@ struct raid_base_bdev_info {
 	/* pointer to base bdev descriptor opened by raid bdev */
 	struct spdk_bdev_desc	*desc;
 
-    /* position of the base bdev in raid_bdev's base_bdev_info (slot) */
-    uint32_t position;
+	/* position of the base bdev in raid_bdev's base_bdev_info (slot) */
+	uint32_t position;
 
-    /* indicate if the metadata was on disk or not */
-    bool is_new;
+	/* indicate if the metadata was on disk or not */
+	bool is_new;
 
-    /* base bdev's superblock */
-    struct raid_superblock  *raid_sb;
+	/* base bdev's superblock */
+	struct raid_superblock  *raid_sb;
 
 	/* offset in blocks from the start of the base bdev to the start of the data region */
 	uint64_t		data_offset;
@@ -197,8 +197,8 @@ struct raid_bdev {
 	/* state of raid bdev */
 	enum raid_bdev_state		state;
 
-    /* indicate if raid is new for  */
-    bool                is_new;
+	/* indicate if raid is new for  */
+	bool				is_new;
 
 	/* number of base bdevs comprising raid bdev  */
 	uint8_t				num_base_bdevs;

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -115,9 +115,6 @@ struct raid_base_bdev_info {
     /* indicate if the metadata was on disk or not */
     bool is_new;
 
-    /* true if sb has loaded */
-    bool sb_loaded;
-
     /* base bdev's superblock */
     struct raid_superblock  *raid_sb;
 

--- a/module/bdev/raid/bdev_raid.h
+++ b/module/bdev/raid/bdev_raid.h
@@ -13,6 +13,8 @@
 
 #define RAID_SUPERBLOCK_MAGIC 0x534B5244 /* "SKRD" */
 
+#define RAID_SB_BLOCKS(bdev_blocklen) spdk_divide_round_up(sizeof(struct raid_superblock), bdev_blocklen)
+
 enum raid_level {
 	INVALID_RAID_LEVEL	= -1,
 	RAID0			= 0,

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -134,8 +134,8 @@ struct rpc_bdev_raid_create {
 	/* If set, information about raid bdev will be stored in superblock on each base bdev */
 	bool                                 superblock_enabled;
 
-    /* If set, it tries to retrieve raid array from the base bdevs and fail if it can't */
-    bool                                 retrieve;
+	/* If set, it tries to retrieve raid array from the base bdevs and fail if it can't */
+	bool                                 retrieve;
 };
 
 /*
@@ -202,7 +202,7 @@ static const struct spdk_json_object_decoder rpc_bdev_raid_create_decoders[] = {
 	{"base_bdevs", offsetof(struct rpc_bdev_raid_create, base_bdevs), decode_base_bdevs},
 	{"uuid", offsetof(struct rpc_bdev_raid_create, uuid), spdk_json_decode_uuid, true},
 	{"superblock", offsetof(struct rpc_bdev_raid_create, superblock_enabled), spdk_json_decode_bool, true},
-    {"retrieve", offsetof(struct rpc_bdev_raid_create, retrieve), spdk_json_decode_bool, true}
+	{"retrieve", offsetof(struct rpc_bdev_raid_create, retrieve), spdk_json_decode_bool, true}
 };
 
 /*
@@ -232,12 +232,12 @@ rpc_bdev_raid_create(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
-    if (!req.superblock_enabled && req.retrieve) {
-        spdk_jsonrpc_send_error_response_fmt(request, -EINVAL,
-                                             "Retrieve option can be only if superblock is specified: %s",
-                                             spdk_strerror(-EINVAL));
-        goto cleanup;
-    }
+	if (!req.superblock_enabled && req.retrieve) {
+		spdk_jsonrpc_send_error_response_fmt(request, -EINVAL,
+											 "Retrieve option can be only if superblock is specified: %s",
+											 spdk_strerror(-EINVAL));
+		goto cleanup;
+	}
 
 	rc = raid_bdev_create(req.name, req.strip_size_kb, req.base_bdevs.num_base_bdevs,
 			      req.level, req.superblock_enabled, &req.uuid, &raid_bdev);
@@ -248,9 +248,9 @@ rpc_bdev_raid_create(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
-    if (req.retrieve) {
-        raid_bdev->is_new = false;
-    }
+	if (req.retrieve) {
+		raid_bdev->is_new = false;
+	}
 
 	for (i = 0; i < req.base_bdevs.num_base_bdevs; i++) {
 		const char *base_bdev_name = req.base_bdevs.base_bdevs[i];

--- a/module/bdev/raid/bdev_raid_rpc.c
+++ b/module/bdev/raid/bdev_raid_rpc.c
@@ -133,6 +133,9 @@ struct rpc_bdev_raid_create {
 
 	/* If set, information about raid bdev will be stored in superblock on each base bdev */
 	bool                                 superblock_enabled;
+
+    /* If set, it tries to retrieve raid array from the base bdevs and fail if it can't */
+    bool                                 retrieve;
 };
 
 /*
@@ -199,6 +202,7 @@ static const struct spdk_json_object_decoder rpc_bdev_raid_create_decoders[] = {
 	{"base_bdevs", offsetof(struct rpc_bdev_raid_create, base_bdevs), decode_base_bdevs},
 	{"uuid", offsetof(struct rpc_bdev_raid_create, uuid), spdk_json_decode_uuid, true},
 	{"superblock", offsetof(struct rpc_bdev_raid_create, superblock_enabled), spdk_json_decode_bool, true},
+    {"retrieve", offsetof(struct rpc_bdev_raid_create, retrieve), spdk_json_decode_bool, true}
 };
 
 /*
@@ -228,6 +232,13 @@ rpc_bdev_raid_create(struct spdk_jsonrpc_request *request,
 		goto cleanup;
 	}
 
+    if (!req.superblock_enabled && req.retrieve) {
+        spdk_jsonrpc_send_error_response_fmt(request, -EINVAL,
+                                             "Retrieve option can be only if superblock is specified: %s",
+                                             spdk_strerror(-EINVAL));
+        goto cleanup;
+    }
+
 	rc = raid_bdev_create(req.name, req.strip_size_kb, req.base_bdevs.num_base_bdevs,
 			      req.level, req.superblock_enabled, &req.uuid, &raid_bdev);
 	if (rc != 0) {
@@ -236,6 +247,10 @@ rpc_bdev_raid_create(struct spdk_jsonrpc_request *request,
 						     req.name, spdk_strerror(-rc));
 		goto cleanup;
 	}
+
+    if (req.retrieve) {
+        raid_bdev->is_new = false;
+    }
 
 	for (i = 0; i < req.base_bdevs.num_base_bdevs; i++) {
 		const char *base_bdev_name = req.base_bdevs.base_bdevs[i];

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -434,6 +434,22 @@ def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, stri
     return client.call('bdev_raid_create', params)
 
 
+def bdev_raid_retrieve(client, name, base_bdevs):
+    """Wrapper of bdev_raid_create. Tried to retrieve raid array from base bdevs.
+
+    Args:
+        name: user defined raid bdev name for retrieved raid
+        base_bdevs: Space separated names of retrieving array base bdevs in double quotes,
+                    like "Nvme0n1 Nvme1n1 Nvme2n1"
+
+    Returns:
+        None
+    """
+    params = {'name': name, 'raid_level': "raid1", 'base_bdevs': base_bdevs, 'superblock': True, 'retrieve': True}
+
+    return client.call('bdev_raid_retrieve', params)
+
+
 def bdev_raid_delete(client, name):
     """Delete raid bdev
 

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -445,9 +445,9 @@ def bdev_raid_retrieve(client, name, base_bdevs):
     Returns:
         None
     """
-    params = {'name': name, 'raid_level': "raid1", 'base_bdevs': base_bdevs, 'superblock': True, 'retrieve': True}
+    params = {'name': name, 'raid_level': 'raid1', 'base_bdevs': base_bdevs, 'superblock': True, 'retrieve': True}
 
-    return client.call('bdev_raid_retrieve', params)
+    return client.call('bdev_raid_create', params)
 
 
 def bdev_raid_delete(client, name):

--- a/python/spdk/rpc/bdev.py
+++ b/python/spdk/rpc/bdev.py
@@ -402,7 +402,8 @@ def bdev_raid_get_bdevs(client, category):
     return client.call('bdev_raid_get_bdevs', params)
 
 
-def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, strip_size_kb=None, uuid=None, superblock=False):
+def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, strip_size_kb=None, uuid=None, superblock=False,
+                     retrieve=False):
     """Create raid bdev. Either strip size arg will work but one is required.
 
     Args:
@@ -414,11 +415,12 @@ def bdev_raid_create(client, name, raid_level, base_bdevs, strip_size=None, stri
         uuid: UUID for this raid bdev (optional)
         superblock: information about raid bdev will be stored in superblock on each base bdev,
                     disabled by default due to backward compatibility
+        retrieve: if specified, try to retrieve raid from superblock in base bdevs
 
     Returns:
         None
     """
-    params = {'name': name, 'raid_level': raid_level, 'base_bdevs': base_bdevs, 'superblock': superblock}
+    params = {'name': name, 'raid_level': raid_level, 'base_bdevs': base_bdevs, 'superblock': superblock,  'retrieve': retrieve}
 
     if strip_size:
         params['strip_size'] = strip_size

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2130,7 +2130,8 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
                                   raid_level=args.raid_level,
                                   base_bdevs=base_bdevs,
                                   uuid=args.uuid,
-                                  superblock=args.superblock)
+                                  superblock=args.superblock,
+                                  retrieve=args.retrieve)
     p = subparsers.add_parser('bdev_raid_create', help='Create new raid bdev')
     p.add_argument('-n', '--name', help='raid bdev name', required=True)
     p.add_argument('-z', '--strip-size-kb', help='strip size in KB', type=int)
@@ -2139,6 +2140,8 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('--uuid', help='UUID for this raid bdev', required=False)
     p.add_argument('-s', '--superblock', help='information about raid bdev will be stored in superblock on each base bdev, '
                                               'disabled by default due to backward compatibility', action='store_true')
+    p.add_argument('--retrieve', help='try to recreate raid from superblock on base bdevs, it works only if superblock'
+                                      'option specified', action='store_true')
     p.set_defaults(func=bdev_raid_create)
 
     def bdev_raid_delete(args):

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2144,6 +2144,20 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
                                       'option specified', action='store_true')
     p.set_defaults(func=bdev_raid_create)
 
+    def bdev_raid_retrieve(args):
+        base_bdevs = []
+        for u in args.base_bdevs.strip().split(" "):
+            base_bdevs.append(u)
+
+        rpc.bdev.bdev_raid_create(args.client,
+                                  name=args.name,
+                                  base_bdevs=base_bdevs)
+    p = subparsers.add_parser('bdev_raid_retrieve', help='Try to restore raid from metadata in base bdevs')
+    p.add_argument('-n', '--name', help='new name for retrieved raid', required=True)
+    p.add_argument('-b', '--base-bdevs', help='base bdevs name whiche have the superblock with raid metadata, '
+                                              'whitespace separated list in quotes', required=True)
+    p.set_defaults(func=bdev_raid_retrieve)
+
     def bdev_raid_delete(args):
         rpc.bdev.bdev_raid_delete(args.client,
                                   name=args.name)

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2149,7 +2149,7 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
         for u in args.base_bdevs.strip().split(" "):
             base_bdevs.append(u)
 
-        rpc.bdev.bdev_raid_create(args.client,
+        rpc.bdev.bdev_raid_retrieve(args.client,
                                   name=args.name,
                                   base_bdevs=base_bdevs)
     p = subparsers.add_parser('bdev_raid_retrieve', help='Try to restore raid from metadata in base bdevs')

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -2140,8 +2140,8 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
     p.add_argument('--uuid', help='UUID for this raid bdev', required=False)
     p.add_argument('-s', '--superblock', help='information about raid bdev will be stored in superblock on each base bdev, '
                                               'disabled by default due to backward compatibility', action='store_true')
-    p.add_argument('--retrieve', help='try to recreate raid from superblock on base bdevs, it works only if superblock'
-                                      'option specified', action='store_true')
+    p.add_argument('--retrieve', help='try to recreate raid from the superblock on the base bdevs, it only works if superblock'
+                                      'option is specified', action='store_true')
     p.set_defaults(func=bdev_raid_create)
 
     def bdev_raid_retrieve(args):
@@ -2152,9 +2152,9 @@ Format: 'user:u1 secret:s1 muser:mu1 msecret:ms1,user:u2 secret:s2 muser:mu2 mse
         rpc.bdev.bdev_raid_retrieve(args.client,
                                   name=args.name,
                                   base_bdevs=base_bdevs)
-    p = subparsers.add_parser('bdev_raid_retrieve', help='Try to restore raid from metadata in base bdevs')
-    p.add_argument('-n', '--name', help='new name for retrieved raid', required=True)
-    p.add_argument('-b', '--base-bdevs', help='base bdevs name whiche have the superblock with raid metadata, '
+    p = subparsers.add_parser('bdev_raid_retrieve', help='Try to restore the raid from metadata on the base bdevs')
+    p.add_argument('-n', '--name', help='new name for the retrieved raid', required=True)
+    p.add_argument('-b', '--base-bdevs', help='name of the base bdevs which have the superblock with raid metadata, '
                                               'whitespace separated list in quotes', required=True)
     p.set_defaults(func=bdev_raid_retrieve)
 


### PR DESCRIPTION
Add metadata to the raid module. Now it is possible to retrieve raid from base bdevs. Also add CLI interface for it in rpc.py.

Updating of metadata not implemented yet.